### PR TITLE
Add missing include of NS resource

### DIFF
--- a/lib/Net/DNS/Message/Resource.pm6
+++ b/lib/Net/DNS/Message/Resource.pm6
@@ -4,6 +4,7 @@ use Net::DNS::Message::Resource::A;
 use Net::DNS::Message::Resource::AAAA;
 use Net::DNS::Message::Resource::CNAME;
 use Net::DNS::Message::Resource::MX;
+use Net::DNS::Message::Resource::NS;
 use Net::DNS::Message::Resource::PTR;
 use Net::DNS::Message::Resource::SPF;
 use Net::DNS::Message::Resource::SRV;


### PR DESCRIPTION
Running a simple test was giving the error message

===SORRY!===
Could not find symbol '&NS'

A bit of simple searching suggested this fairly obvious patch.
