### PR TITLE
Add unit declarator to class and role declarations

### DIFF
--- a/lib/Net/DNS.pm6
+++ b/lib/Net/DNS.pm6
@@ -1,4 +1,4 @@
-class Net::DNS;
+unit class Net::DNS;
 
 use Net::DNS::Message;
 

--- a/lib/Net/DNS/Message.pm6
+++ b/lib/Net/DNS/Message.pm6
@@ -1,4 +1,4 @@
-class Net::DNS::Message;
+unit class Net::DNS::Message;
 
 use Net::DNS::Message::Header;
 use Net::DNS::Message::Question;

--- a/lib/Net/DNS/Message/DomainName.pm6
+++ b/lib/Net/DNS/Message/DomainName.pm6
@@ -1,4 +1,4 @@
-role Net::DNS::Message::DomainName;
+unit role Net::DNS::Message::DomainName;
 
 method parse-domain-name($data is copy, %name-offsets is rw, $start-offset) {
     my @offset-list = (0);

--- a/lib/Net/DNS/Message/Header.pm6
+++ b/lib/Net/DNS/Message/Header.pm6
@@ -1,4 +1,4 @@
-class Net::DNS::Message::Header;
+unit class Net::DNS::Message::Header;
 
 has Int $.id is rw = 0;
 has Int $.qr is rw = 0;

--- a/lib/Net/DNS/Message/Question.pm6
+++ b/lib/Net/DNS/Message/Question.pm6
@@ -1,6 +1,6 @@
 use Net::DNS::Message::DomainName;
 
-class Net::DNS::Message::Question does Net::DNS::Message::DomainName;
+unit class Net::DNS::Message::Question does Net::DNS::Message::DomainName;
 
 has Str @.qname is rw;
 has Int $.qtype is rw = 0;

--- a/lib/Net/DNS/Message/Resource.pm6
+++ b/lib/Net/DNS/Message/Resource.pm6
@@ -11,7 +11,7 @@ use Net::DNS::Message::Resource::SRV;
 use Net::DNS::Message::Resource::TXT;
 use Net::DNS::Message::Resource::SOA;
 
-class Net::DNS::Message::Resource does Net::DNS::Message::DomainName;
+unit class Net::DNS::Message::Resource does Net::DNS::Message::DomainName;
 
 has Str @.name is rw;
 has Int $.type is rw = 0;

--- a/lib/Net/DNS/Message/Resource/A.pm6
+++ b/lib/Net/DNS/Message/Resource/A.pm6
@@ -1,4 +1,4 @@
-role Net::DNS::Message::Resource::A;
+unit role Net::DNS::Message::Resource::A;
 
 class Net::DNS::A {
     has @.owner-name;

--- a/lib/Net/DNS/Message/Resource/AAAA.pm6
+++ b/lib/Net/DNS/Message/Resource/AAAA.pm6
@@ -1,4 +1,4 @@
-role Net::DNS::Message::Resource::AAAA;
+unit role Net::DNS::Message::Resource::AAAA;
 
 class Net::DNS::AAAA {
     has @.owner-name;

--- a/lib/Net/DNS/Message/Resource/CNAME.pm6
+++ b/lib/Net/DNS/Message/Resource/CNAME.pm6
@@ -1,4 +1,4 @@
-role Net::DNS::Message::Resource::CNAME;
+unit role Net::DNS::Message::Resource::CNAME;
 
 class Net::DNS::CNAME {
     has @.owner-name;

--- a/lib/Net/DNS/Message/Resource/MX.pm6
+++ b/lib/Net/DNS/Message/Resource/MX.pm6
@@ -1,4 +1,4 @@
-role Net::DNS::Message::Resource::MX;
+unit role Net::DNS::Message::Resource::MX;
 
 class Net::DNS::MX {
     has @.owner-name;

--- a/lib/Net/DNS/Message/Resource/NS.pm6
+++ b/lib/Net/DNS/Message/Resource/NS.pm6
@@ -1,4 +1,4 @@
-role Net::DNS::Message::Resource::NS;
+unit role Net::DNS::Message::Resource::NS;
 
 class Net::DNS::NS {
     has @.owner-name;

--- a/lib/Net/DNS/Message/Resource/PTR.pm6
+++ b/lib/Net/DNS/Message/Resource/PTR.pm6
@@ -1,4 +1,4 @@
-role Net::DNS::Message::Resource::PTR;
+unit role Net::DNS::Message::Resource::PTR;
 
 class Net::DNS::PTR {
     has @.owner-name;

--- a/lib/Net/DNS/Message/Resource/SOA.pm6
+++ b/lib/Net/DNS/Message/Resource/SOA.pm6
@@ -1,4 +1,4 @@
-role Net::DNS::Message::Resource::SOA;
+unit role Net::DNS::Message::Resource::SOA;
 
 class Net::DNS::SOA {
     has @.owner-name;

--- a/lib/Net/DNS/Message/Resource/SPF.pm6
+++ b/lib/Net/DNS/Message/Resource/SPF.pm6
@@ -1,4 +1,4 @@
-role Net::DNS::Message::Resource::SPF;
+unit role Net::DNS::Message::Resource::SPF;
 
 class Net::DNS::SPF {
     has @.owner-name;

--- a/lib/Net/DNS/Message/Resource/SRV.pm6
+++ b/lib/Net/DNS/Message/Resource/SRV.pm6
@@ -1,4 +1,4 @@
-role Net::DNS::Message::Resource::SRV;
+unit role Net::DNS::Message::Resource::SRV;
 
 class Net::DNS::SRV {
     has @.owner-name;

--- a/lib/Net/DNS/Message/Resource/TXT.pm6
+++ b/lib/Net/DNS/Message/Resource/TXT.pm6
@@ -1,4 +1,4 @@
-role Net::DNS::Message::Resource::TXT;
+unit role Net::DNS::Message::Resource::TXT;
 
 class Net::DNS::TXT {
     has @.owner-name;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.