### PR TITLE
Change to more reliable test locations

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,8 +1,6 @@
 use v6;
 use Test;
 
-plan 6;
-
 my $server = %*ENV<DNS_TEST_HOST> // '8.8.8.8';
 
 use Net::DNS;
@@ -14,8 +12,13 @@ say '# using %*ENV<DNS_TEST_HOST> = '~$server if $server ne '8.8.8.8';
 ok ($resolver = Net::DNS.new($server)), "Created a resolver";
 
 my $response;
-ok ($response = $resolver.lookup("A", "perl6.org")), "Lookup A record for perl6.org...";
-ok ($response[0] eq "213.95.82.53"), "...Got a valid response!"; # this will probably need to change in the future
+ok ($response = $resolver.lookup("A", "dns.google")), "Lookup A record for raku.org...";
 
-ok ($response = $resolver.lookup("A", "perl6.org.")), "Lookup A record for perl6.org. (with trailing dot)...";
-ok ($response[0] eq "213.95.82.53"), "...Got a valid response!"; # this will probably need to change in the future
+ok ($response[0] eq "8.8.4.4"), "...Got a valid response!"; # this will probably need to change in the future
+ok ($response[1] eq "8.8.8.8"), "...Got a valid response!"; # this will probably need to change in the future
+
+ok ($response = $resolver.lookup("A", "dns.google.")), "Lookup A record for raku.org. (with trailing dot)...";
+ok ($response[0] eq "8.8.4.4"), "...Got a valid response!"; # this will probably need to change in the future
+ok ($response[1] eq "8.8.8.8"), "...Got a valid response!"; # this will probably need to change in the future
+
+done-testing;

--- a/t/02-lookup-ips.t
+++ b/t/02-lookup-ips.t
@@ -12,5 +12,5 @@ say '# using %*ENV<DNS_TEST_HOST> = '~$server if $server ne '8.8.8.8';
 ok ($resolver = Net::DNS.new($server)), "Created a resolver";
 
 my $response;
-ok ($response = $resolver.lookup-ips("perl6.org")), "Lookup ips for perl6.org...";
-ok ($response[0] eq "213.95.82.53"), "...Got a valid response!"; # this will probably need to change in the future
+ok ($response = $resolver.lookup-ips("raku.org")), "Lookup ips for raku.org...";
+ok ($response[2].Str ~~ ("104.18.58.39", '104.18.59.39').any), "...Got a valid response!"; # this will probably need to change in the future

--- a/t/03-lookup-mx.t
+++ b/t/03-lookup-mx.t
@@ -12,5 +12,5 @@ say '# using %*ENV<DNS_TEST_HOST> = '~$server if $server ne '8.8.8.8';
 ok ($resolver = Net::DNS.new($server)), "Created a resolver";
 
 my $response;
-ok ($response = $resolver.lookup-mx("perl6.org")), "Lookup mx for perl6.org...";
-ok ($response[0] eq "66.39.3.26"), "...Got a valid response!"; # this will probably need to change in the future
+ok ($response = $resolver.lookup-mx("raku.org")), "Lookup mx for raku.org...";
+ok ($response[0] eq "80.127.186.58"), "...Got a valid response!"; # this will probably need to change in the future


### PR DESCRIPTION
All 3 tests were failing for me, requiring zef install --force-test.

Test 1 uses dns.google which should be consistent.
Test 2/3 use Raku.org with multiple IPs where appropriate for round-robin used internally.

Fixes #18 and replaces #17.