### PR TITLE
Improve tests

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -2,7 +2,7 @@ use v6;
 
 use Test;
 
-plan 8;
+plan 6;
 
 my $server = %*ENV<DNS_TEST_HOST> // '8.8.8.8';
 
@@ -17,17 +17,15 @@ unless %*ENV<NETWORK_TESTING> {
 ok True, "Module loaded";
 
 my $resolver;
-say '# using %*ENV<DNS_TEST_HOST> = '~$server if $server ne '8.8.8.8';
+diag '# using %*ENV<DNS_TEST_HOST> = '~$server if $server ne '8.8.8.8';
 ok ($resolver = Net::DNS.new($server)), "Created a resolver";
 
 my $response;
-ok ($response = $resolver.lookup("A", "dns.google")), "Lookup A record for raku.org...";
+ok ($response = $resolver.lookup("A", "dns.google")), "Lookup A record for dns.google...";
 
-ok ($response[0] eq "8.8.4.4"), "...Got a valid response!"; # this will probably need to change in the future
-ok ($response[1] eq "8.8.8.8"), "...Got a valid response!"; # this will probably need to change in the future
+is $response.sort, ["8.8.4.4", "8.8.8.8"], "...Got a valid response!"; # this will probably need to change in the future
 
-ok ($response = $resolver.lookup("A", "dns.google.")), "Lookup A record for raku.org. (with trailing dot)...";
-ok ($response[0] eq "8.8.4.4"), "...Got a valid response!"; # this will probably need to change in the future
-ok ($response[1] eq "8.8.8.8"), "...Got a valid response!"; # this will probably need to change in the future
+ok ($response = $resolver.lookup("A", "dns.google.")), "Lookup A record for dns.google. (with trailing dot)...";
+is $response.sort, ["8.8.4.4", "8.8.8.8"], "...Got a valid response!"; # this will probably need to change in the future
 
 done-testing;

--- a/t/03-lookup-mx.t
+++ b/t/03-lookup-mx.t
@@ -13,13 +13,33 @@ unless %*ENV<NETWORK_TESTING> {
     exit;
 }
 
+# Define an IPv4/IPv6 grammar
+# IPv6 part based on Rosetacode
+#   https://rosettacode.org/wiki/Parse_an_IP_Address#Perl_6
+my @octet = ^256;
+grammar IP {
+    token TOP {
+        | ^ <IPv6Addr> $
+        | ^ <IPv4Addr> $
+    }
+
+    token IPv6Addr {
+        | <h16> +% ':' <?{ $<h16> == 8}>
+        | [ (<h16>) +% ':']? '::' [ (<h16>) +% ':' ]? <?{ @$0 + @$1 ≤ 8 }>
+    }
+
+    token IPv4Addr { @octet**4 % '.' }
+
+    token h16 { (<:hexdigit>+) <?{ @$0 ≤ 4 }> }
+}
+
 my $resolver;
-say '# using %*ENV<DNS_TEST_HOST> = '~$server if $server ne '8.8.8.8';
+diag '# using %*ENV<DNS_TEST_HOST> = '~$server if $server ne '8.8.8.8';
 ok ($resolver = Net::DNS.new($server)), "Created a resolver";
 
 my $response;
 ok ($response = $resolver.lookup-mx("raku.org")), "Lookup mx for raku.org...";
-ok ($response[0] eq "80.127.186.58"), "...Got a valid response!"; # this will probably need to change in the future
+ok IP.parse($response[0].Str), "...Got a valid response!"; # this will probably need to change in the future
 
 my $mx = $resolver.lookup-mx('junk.rrr');
 ok $mx ~~ Failure, 'Failure Response';


### PR DESCRIPTION
I did a few things to improve the tests (they failed for me when run with NETWORK_TESTING set):

- Test descriptions were misleading in some cases, when dns.google was tested (the description indicated it was raku.org), so I updated the description.
- Tests in 01-basic assumed the order of responses for dns.google, however the order can be random, so I've updated the test to account for this.
- Changed "say" to "diag" in tests so that TAP consumers can better deal with it
- In 02-lookup-ips and 03-lookup-mx to just check for valid IPv4 or IPv6 addresses, rather than specific IPs, as raku.org is behind Cloudflare, so different IPs will be handed out in different regions of the world. I also assumed some similar possibility for the MX records.

I intend to submit an additional record tiype of RRSIG to the code base in the next day or two, so that I can do lookups on RRSIGs for something I'm needing, so if you like this PR, you might wait for the next one before doing a release or such.